### PR TITLE
Update Plugin.swift

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -67,8 +67,6 @@ public class FirebaseRemoteConfig: CAPPlugin {
                 call.error("Error occured while executing failAndActivate()")
             }
         })
-        
-        call.success()
     }
     
     @objc func getBoolean(_ call: CAPPluginCall) {


### PR DESCRIPTION
Removed default `call.success()` from `fetchAndActivate` method