### PR TITLE
Update to work with firebase 7.0.0 fix: #9

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -36,6 +36,7 @@ public class FirebaseRemoteConfig: CAPPlugin {
             let settings: RemoteConfigSettings = RemoteConfigSettings()
             settings.minimumFetchInterval = TimeInterval(minFetchInterval)
             self.remoteConfig?.configSettings = settings
+            call.success()
         }
     }
     

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -50,7 +50,7 @@ public class FirebaseRemoteConfig: CAPPlugin {
     }
     
     @objc func activate(_ call: CAPPluginCall) {
-        self.remoteConfig?.activate(completionHandler: { (error) in
+        self.remoteConfig?.activate(completion: { (status, error) in
             if error != nil {
                 call.error(error?.localizedDescription ?? "Error occured while executing activate()")
             } else {


### PR DESCRIPTION
Fixes the following error: `node_modules/@capacitor-community/firebase-remote-config/ios/Plugin/Plugin.swift:53:56: extra argument 'completionHandler' in call` and run `call.success()` on initialise complete