### PR TITLE
Adds support for Capacitor v3.

### DIFF
--- a/CapacitorCommunityFirebaseRemoteConfig.podspec
+++ b/CapacitorCommunityFirebaseRemoteConfig.podspec
@@ -8,7 +8,7 @@
     s.author = 'Priyank Patel <priyank.patel@stackspace.ca>'
     s.source = { :git => 'https://github.com/capacitor-community/firebase-remote-config', :tag => s.version.to_s }
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-    s.ios.deployment_target  = '11.0'
+    s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
     s.static_framework = true
     s.dependency 'Firebase/RemoteConfig'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 ext {
     junitVersion =  project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.12'
+    androidxAppCompatVersion =  project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.2.0'
     androidxJunitVersion =  project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.1'
     androidxEspressoCoreVersion =  project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.2.0'
 }
@@ -47,9 +48,9 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-
     implementation 'com.google.firebase:firebase-config:19.1.4'
 }

--- a/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
@@ -3,29 +3,37 @@ package com.getcapacitor.community.firebaserc;
 import static com.getcapacitor.community.firebaserc.Constant.ERROR_MISSING_KEY;
 
 import android.Manifest;
+import android.Manifest;
 import android.content.Context;
+import android.os.Bundle;
 import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Objects;
 
 @CapacitorPlugin(
+  name = "FirebaseRemoteConfig",
   permissions = {
-    @Permission(strings = { Manifest.permission.ACCESS_NETWORK_STATE }, alias = "access_network_state"),
-    @Permission(strings = { Manifest.permission.INTERNET }, alias = "internet")
-    })
+    @Permission(
+      strings = { Manifest.permission.ACCESS_NETWORK_STATE },
+      alias = "network"
+    ),
+    @Permission(strings = { Manifest.permission.INTERNET }, alias = "internet"),
+  }
 )
 public class FirebaseRemoteConfig extends Plugin {
-
   public static final String TAG = "FirebaseRemoteConfig";
 
   private com.google.firebase.remoteconfig.FirebaseRemoteConfig mFirebaseRemoteConfig;
@@ -71,6 +79,7 @@ public class FirebaseRemoteConfig extends Plugin {
       .addOnCompleteListener(
         bridge.getActivity(),
         new OnCompleteListener<Void>() {
+
           @Override
           public void onComplete(@NonNull Task<Void> task) {
             if (task.isSuccessful()) {
@@ -95,6 +104,7 @@ public class FirebaseRemoteConfig extends Plugin {
       .addOnCompleteListener(
         bridge.getActivity(),
         new OnCompleteListener<Boolean>() {
+
           @Override
           public void onComplete(@NonNull Task<Boolean> task) {
             if (task.isSuccessful()) {
@@ -119,6 +129,7 @@ public class FirebaseRemoteConfig extends Plugin {
       .addOnCompleteListener(
         bridge.getActivity(),
         new OnCompleteListener<Boolean>() {
+
           @Override
           public void onComplete(@NonNull Task<Boolean> task) {
             if (task.isSuccessful()) {
@@ -137,6 +148,7 @@ public class FirebaseRemoteConfig extends Plugin {
       )
       .addOnFailureListener(
         new OnFailureListener() {
+
           @Override
           public void onFailure(@NonNull Exception e) {
             call.error(e.getLocalizedMessage());

--- a/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
@@ -18,10 +18,11 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
 import java.util.Collections;
 import java.util.Objects;
 
-@NativePlugin(
+@CapacitorPlugin(
   permissions = {
-    Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.INTERNET,
-  }
+    @Permission(strings = { Manifest.permission.ACCESS_NETWORK_STATE }, alias = "access_network_state"),
+    @Permission(strings = { Manifest.permission.INTERNET }, alias = "internet")
+    })
 )
 public class FirebaseRemoteConfig extends Plugin {
 

--- a/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
@@ -16,6 +16,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
 import java.util.Collections;
+import java.util.Objects;
 
 @NativePlugin(
   permissions = {
@@ -23,6 +24,7 @@ import java.util.Collections;
   }
 )
 public class FirebaseRemoteConfig extends Plugin {
+
   public static final String TAG = "FirebaseRemoteConfig";
 
   private com.google.firebase.remoteconfig.FirebaseRemoteConfig mFirebaseRemoteConfig;
@@ -55,9 +57,11 @@ public class FirebaseRemoteConfig extends Plugin {
   public void initialize(PluginCall call) {
     int minFetchTimeInSecs = call.getInt("minimumFetchIntervalInSeconds", 3600);
     FirebaseRemoteConfigSettings configSettings = new FirebaseRemoteConfigSettings.Builder()
-      .setFetchTimeoutInSeconds(minFetchTimeInSecs)
+      .setMinimumFetchIntervalInSeconds(minFetchTimeInSecs)
       .build();
     this.mFirebaseRemoteConfig.setConfigSettingsAsync(configSettings);
+
+    call.success();
   }
 
   @PluginMethod
@@ -66,15 +70,18 @@ public class FirebaseRemoteConfig extends Plugin {
       .addOnCompleteListener(
         bridge.getActivity(),
         new OnCompleteListener<Void>() {
-
           @Override
           public void onComplete(@NonNull Task<Void> task) {
             if (task.isSuccessful()) {
               call.success();
             } else if (task.isCanceled()) {
-              call.error(task.getException().getMessage());
+              call.error(
+                Objects.requireNonNull(task.getException()).getMessage()
+              );
             } else {
-              call.error(task.getException().getMessage());
+              call.error(
+                Objects.requireNonNull(task.getException()).getMessage()
+              );
             }
           }
         }
@@ -87,15 +94,18 @@ public class FirebaseRemoteConfig extends Plugin {
       .addOnCompleteListener(
         bridge.getActivity(),
         new OnCompleteListener<Boolean>() {
-
           @Override
           public void onComplete(@NonNull Task<Boolean> task) {
             if (task.isSuccessful()) {
               call.success();
             } else if (task.isCanceled()) {
-              call.error(task.getException().getMessage());
+              call.error(
+                Objects.requireNonNull(task.getException()).getMessage()
+              );
             } else {
-              call.error(task.getException().getMessage());
+              call.error(
+                Objects.requireNonNull(task.getException()).getMessage()
+              );
             }
           }
         }
@@ -108,22 +118,24 @@ public class FirebaseRemoteConfig extends Plugin {
       .addOnCompleteListener(
         bridge.getActivity(),
         new OnCompleteListener<Boolean>() {
-
           @Override
           public void onComplete(@NonNull Task<Boolean> task) {
             if (task.isSuccessful()) {
               call.success();
             } else if (task.isCanceled()) {
-              call.error(task.getException().getMessage());
+              call.error(
+                Objects.requireNonNull(task.getException()).getMessage()
+              );
             } else {
-              call.error(task.getException().getMessage());
+              call.error(
+                Objects.requireNonNull(task.getException()).getMessage()
+              );
             }
           }
         }
       )
       .addOnFailureListener(
         new OnFailureListener() {
-
           @Override
           public void onFailure(@NonNull Exception e) {
             call.error(e.getLocalizedMessage());

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -6,7 +6,7 @@
 CAP_PLUGIN(FirebaseRemoteConfig, "FirebaseRemoteConfig",
            CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetch, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(active, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(activate, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetchAndActivate, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getBoolean, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getString, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -9,36 +9,38 @@ import FirebaseRemoteConfig
  */
 @objc(FirebaseRemoteConfig)
 public class FirebaseRemoteConfig: CAPPlugin {
-    
+
     var remoteConfig: RemoteConfig?
-    
+
     public override func load() {
         if (FirebaseApp.app() == nil) {
           FirebaseApp.configure();
         }
-        
+
         if self.remoteConfig == nil {
             self.remoteConfig = RemoteConfig.remoteConfig()
-            
+
             let standardUserDefaults = UserDefaults.standard
             let remoteConfigDefaults = standardUserDefaults.object(forKey: "FirebaseRemoteConfigDefaults".lowercased())
-            
+
             if remoteConfigDefaults != nil {
                 self.remoteConfig?.setDefaults(fromPlist: remoteConfigDefaults as? String)
             }
         }
     }
-    
+
     @objc func initialize(_ call: CAPPluginCall) {
         let minFetchInterval = call.getInt("minimumFetchIntervalInSeconds") ?? 0
-        
+
         if self.remoteConfig != nil {
             let settings: RemoteConfigSettings = RemoteConfigSettings()
             settings.minimumFetchInterval = TimeInterval(minFetchInterval)
             self.remoteConfig?.configSettings = settings
         }
+
+        call.success()
     }
-    
+
     @objc func fetch(_ call: CAPPluginCall) {
         self.remoteConfig?.fetch(completionHandler: { (status, error) in
             if status == .success {
@@ -48,9 +50,9 @@ public class FirebaseRemoteConfig: CAPPlugin {
             }
         })
     }
-    
+
     @objc func activate(_ call: CAPPluginCall) {
-        self.remoteConfig?.activate(completionHandler: { (error) in
+        self.remoteConfig?.activate(completion: { (status, error) in
             if error != nil {
                 call.error(error?.localizedDescription ?? "Error occured while executing activate()")
             } else {
@@ -58,7 +60,7 @@ public class FirebaseRemoteConfig: CAPPlugin {
             }
         })
     }
-    
+
     @objc func fetchAndActivate(_ call: CAPPluginCall) {
         self.remoteConfig?.fetchAndActivate(completionHandler: { (status, error) in
             if status == .successFetchedFromRemote || status == .successUsingPreFetchedData {
@@ -68,11 +70,11 @@ public class FirebaseRemoteConfig: CAPPlugin {
             }
         })
     }
-    
+
     @objc func getBoolean(_ call: CAPPluginCall) {
         if call.hasOption("key") {
             let key = call.getString("key")
-            
+
             if key != nil {
                 let value = self.remoteConfig?.configValue(forKey: key).boolValue
                 let source = self.remoteConfig?.configValue(forKey: key).source
@@ -88,11 +90,11 @@ public class FirebaseRemoteConfig: CAPPlugin {
             call.error("Key is missing")
         }
     }
-    
+
     @objc func getNumber(_ call: CAPPluginCall) {
         if call.hasOption("key") {
             let key = call.getString("key")
-            
+
             if key != nil {
                 let value = self.remoteConfig?.configValue(forKey: key).numberValue
                 let source = self.remoteConfig?.configValue(forKey: key).source
@@ -108,11 +110,11 @@ public class FirebaseRemoteConfig: CAPPlugin {
             call.error("Key is missing")
         }
     }
-    
+
     @objc func getString(_ call: CAPPluginCall) {
         if call.hasOption("key") {
             let key = call.getString("key")
-            
+
             if key != nil {
                 let value = self.remoteConfig?.configValue(forKey: key).stringValue
                 let source = self.remoteConfig?.configValue(forKey: key).source
@@ -128,7 +130,7 @@ public class FirebaseRemoteConfig: CAPPlugin {
             call.error("Key is missing")
         }
     }
-    
+
     @objc func getByteArray(_ call: CAPPluginCall) {
         call.success()
     }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,6 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'Firebase/Auth'
   pod 'Firebase/RemoteConfig'
 end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,23 +83,30 @@
       }
     },
     "@capacitor/android": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-2.2.0.tgz",
-      "integrity": "sha512-mFRGfaA/crSHH6P8PYAIDBXL4LFCsjgRhSqzfTMo1+PPnDsZ77Wy01FtB1EN5JVCRgb+Y1YIChcbf5F2Qn5ZjQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.1.1.tgz",
+      "integrity": "sha512-f4QA0wlhr3uRFzHArSQRfgSGXiAFUlCXYOt/TyYwhKIweyrpfzXtHkgqCC4ATqN9Rp7yrrLRnz8JDXBUjff3iw==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-ClxXjOUCF0wZpznZI6f6uXK2LLzWBx5Ly/g7Hqu8R8wNdaKYoh83eMuT+m5G1gfxhcALAAJNUhHccnCW3ohftg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-VTOdy2GZPLxMGDmwXWfhQWoP7G+0XE8gx2er2uo8e8Y6K8YjT8bxqlOL4VJ8gC5X8Wq281SR4OsajzhdgDazgQ==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "@capacitor/ios": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-2.2.0.tgz",
-      "integrity": "sha512-mMz09NG7PYygoAtPJEBRiCjANHRfFT5WcTrFxILRYsgrLct4LhZ7ejaj9En3NGCvwnTG/J+89U2nxxlw2WisOw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.1.1.tgz",
+      "integrity": "sha512-T8HWF2QNhMPb8EjO3Fn6Gmxg7llDPdb8K4mDe977Ufxq0WFuwlQw+VbSDzVXCHhkd2askyDCbpVUh5npONVwTQ==",
       "dev": true
     },
     "@samverschueren/stream-to-observable": {
@@ -2935,7 +2942,8 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.11.0",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,9 +1,3 @@
-declare module "@capacitor/core" {
-  interface PluginRegistry {
-    FirebaseRemoteConfig: FirebaseRemoteConfigPlugin;
-  }
-}
-
 export interface FirebaseRemoteConfigPlugin {
   initializeFirebase(options: any): Promise<void>;
   setDefaultWebConfig(options: any): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,12 @@
+import { registerPlugin } from '@capacitor/core';
+
+import type { FirebaseRemoteConfigPlugin } from './definitions';
+
+const FirebaseRemoteConfigPlugin = registerPlugin<FirebaseRemoteConfigPlugin>(
+  'FirebaseRemoteConfigPlugin',
+  {
+    web: () => import('./web').then(m => new m.FirebaseRemoteConfigWeb()),
+  },
+);
 export * from './definitions';
-export * from './web';
+export { FirebaseRemoteConfigPlugin };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { registerPlugin } from "@capacitor/core";
 import type { FirebaseRemoteConfigPlugin } from "./definitions";
 
 const FirebaseRemoteConfig = registerPlugin<FirebaseRemoteConfigPlugin>(
-  "FirebaseRemoteConfigPlugin",
+  "FirebaseRemoteConfig",
   {
     web: () => import("./web").then((m) => new m.FirebaseRemoteConfigWeb()),
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { registerPlugin } from '@capacitor/core';
+import { registerPlugin } from "@capacitor/core";
 
-import type { FirebaseRemoteConfigPlugin } from './definitions';
+import type { FirebaseRemoteConfigPlugin } from "./definitions";
 
-const FirebaseRemoteConfigPlugin = registerPlugin<FirebaseRemoteConfigPlugin>(
-  'FirebaseRemoteConfigPlugin',
+const FirebaseRemoteConfig = registerPlugin<FirebaseRemoteConfigPlugin>(
+  "FirebaseRemoteConfigPlugin",
   {
-    web: () => import('./web').then(m => new m.FirebaseRemoteConfigWeb()),
-  },
+    web: () => import("./web").then((m) => new m.FirebaseRemoteConfigWeb()),
+  }
 );
-export * from './definitions';
-export { FirebaseRemoteConfigPlugin };
+export * from "./definitions";
+export { FirebaseRemoteConfig };

--- a/src/web.ts
+++ b/src/web.ts
@@ -221,7 +221,7 @@ export class FirebaseRemoteConfigWeb extends WebPlugin
       if (window.firebase && this.isFirebaseInitialized()) {
         this.remoteConfigRef = window.firebase.remoteConfig();
       } else {
-        console.reject("Firebase App has not yet initialized.");
+        console.error("Firebase App has not yet initialized.");
       }
     } catch (error) {
       throw error;

--- a/src/web.ts
+++ b/src/web.ts
@@ -271,10 +271,3 @@ export class FirebaseRemoteConfigWeb extends WebPlugin
     return true;
   }
 }
-
-const FirebaseRemoteConfig = new FirebaseRemoteConfigWeb();
-
-export { FirebaseRemoteConfig };
-
-import { registerWebPlugin } from "@capacitor/core";
-registerWebPlugin(FirebaseRemoteConfig);

--- a/src/web.ts
+++ b/src/web.ts
@@ -253,7 +253,7 @@ export class FirebaseRemoteConfigWeb extends WebPlugin
         file.id = script.key;
         file.onload = resolve;
         file.onerror = reject;
-        document.querySelector("head").appendChild(file);
+        document.querySelector("head")!.appendChild(file);
       });
     });
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -221,7 +221,7 @@ export class FirebaseRemoteConfigWeb extends WebPlugin
       if (window.firebase && this.isFirebaseInitialized()) {
         this.remoteConfigRef = window.firebase.remoteConfig();
       } else {
-        console.error("Firebase App has not yet initialized.");
+        console.reject("Firebase App has not yet initialized.");
       }
     } catch (error) {
       throw error;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,16 +5,16 @@
     "experimentalDecorators": true,
     "lib": [
       "dom",
-      "es2015"
+      "es2017"
     ],
-    "module": "es2015",
+    "module": "es2017",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "dist/esm",
     "sourceMap": true,
-    "target": "es2015"
+    "target": "es2017"
   },
   "files": [
     "src/index.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
-    "lib": [
-      "dom",
-      "es2015"
-    ],
+    "lib": ["dom", "es2015"],
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
@@ -16,9 +13,8 @@
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "strictPropertyInitialization": false
   },
-  "files": [
-    "src/index.ts"
-  ]
+  "files": ["src/index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,21 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
     "declaration": true,
-    "experimentalDecorators": true,
+    "esModuleInterop": true,
     "lib": [
       "dom",
-      "es2017"
+      "es2015"
     ],
-    "module": "es2017",
+    "module": "esnext",
     "moduleResolution": "node",
-    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "dist/esm",
+    "pretty": true,
     "sourceMap": true,
+    "strict": true,
     "target": "es2017"
   },
   "files": [


### PR DESCRIPTION
# What changed?

- Increased the iOS target version
- Replace deprecated code for android
- Added AndroidX `androidxAppCompatVersion`
- Remove unused Pod `pod 'Firebase/Auth'`
- Fix typo `activate`
- Import annotations 
- Register plugin based on cap v3 upgrade docs 

Confirmed Working on Capacitor 3
![Screen Shot 2021-07-07 at 10 34 23 PM](https://user-images.githubusercontent.com/11539276/124853257-917c2f00-df73-11eb-80a9-6463e6afb318.png)

